### PR TITLE
Several Issues resolved: Fix crashes caused by navigating while recor…

### DIFF
--- a/app/src/main/java/de/haw_hamburg/sensorapp/navigation/BottomNavigationActivity.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/navigation/BottomNavigationActivity.java
@@ -33,6 +33,9 @@ public class BottomNavigationActivity extends BaseMvpActivity<BottomNavigationPr
     }
 
     private boolean onNavigationItemSelected(MenuItem menuItem) {
+        if (!notRecording()) {
+            return false;
+        }
         switch (menuItem.getItemId()) {
             case R.id.menu_item_compass:
                 getPresenter().onCompassSelected();
@@ -57,28 +60,41 @@ public class BottomNavigationActivity extends BaseMvpActivity<BottomNavigationPr
 
     @Override
     public void showCompass() {
-        resetRequestedOrientation();
-        showFragment(new CompassFragment());
+        showFragment(new CompassFragment(), "COMPASS");
     }
 
     @Override
     public void showSpiritLevel() {
-        resetRequestedOrientation();
-        showFragment(new SpiritLevelFragment());
+        showFragment(new SpiritLevelFragment(), "SPIRIT");
     }
 
     @Override
     public void showRecorder() {
-        showFragment(new RecorderFragment());
+        showFragment(new RecorderFragment(), "RECORDER");
+    }
+
+    private boolean notRecording() {
+        RecorderFragment fragment = (RecorderFragment)getSupportFragmentManager().findFragmentByTag("RECORDER");
+        if (fragment != null) {
+            if (fragment.getPresenter().isRecording() == true) {
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+        else {
+            return true;
+        }
     }
 
     private void resetRequestedOrientation() {
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR);
     }
 
-    private void showFragment(BaseNavigationFragment fragment) {
+    private void showFragment(BaseNavigationFragment fragment, String tag) {
         getSupportFragmentManager().beginTransaction()
-                .replace(R.id.fragment_container, fragment)
+                .replace(R.id.fragment_container, fragment, tag)
                 .commit();
     }
 }

--- a/app/src/main/java/de/haw_hamburg/sensorapp/recorder/RecorderFragment.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/recorder/RecorderFragment.java
@@ -1,6 +1,7 @@
 package de.haw_hamburg.sensorapp.recorder;
 
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.hardware.SensorEvent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -10,6 +11,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
@@ -77,9 +79,20 @@ public class RecorderFragment extends BaseNavigationFragment<RecorderPresenter, 
     @Override
     public void onResume() {
         super.onResume();
+        if (getActivity() != null) {
+            getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        }
         lineChartPagerAdapter = new SensorLineChartPagerAdapter(getContext());
         lineChartViewPager.setAdapter(lineChartPagerAdapter);
         getPresenter().initialize();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (getPresenter().isRecording()) {
+            getPresenter().stopRecording();
+        }
     }
 
     @Override
@@ -133,11 +146,13 @@ public class RecorderFragment extends BaseNavigationFragment<RecorderPresenter, 
     @Override
     public void showStartButton() {
         controlButton.setText(getString(R.string.recorder_control_start));
+        getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     @Override
     public void showStopButton() {
         controlButton.setText(getString(R.string.recorder_control_stop));
+        getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     @Override

--- a/app/src/main/java/de/haw_hamburg/sensorapp/recorder/RecorderPresenter.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/recorder/RecorderPresenter.java
@@ -63,7 +63,9 @@ public class RecorderPresenter extends AbstractPresenter<RecorderView> {
     }
 
     public void onSettingsMenuItemClicked() {
-        getView().showRecorderSettings();
+        if (recording == false) {
+            getView().showRecorderSettings();
+        }
     }
 
     public void onControlButtonClicked() {
@@ -129,7 +131,7 @@ public class RecorderPresenter extends AbstractPresenter<RecorderView> {
         return sensorDescriptorsProvider.getSensorDescriptor(sensor);
     }
 
-    private void stopRecording() {
+    public void stopRecording() {
         recording = false;
         subscription.unsubscribe();
         closeWriter();

--- a/app/src/main/java/de/haw_hamburg/sensorapp/recorder/SensorLineChart.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/recorder/SensorLineChart.java
@@ -1,7 +1,6 @@
 package de.haw_hamburg.sensorapp.recorder;
 
 import com.github.mikephil.charting.charts.LineChart;
-
 import de.haw_hamburg.sensorapp.recorder.settings.Sensor;
 
 /**
@@ -13,10 +12,12 @@ public class SensorLineChart {
     private final Sensor sensor;
     private final LineChart lineChart;
     private boolean visible;
+    private long lastTimeStamp;
 
     public SensorLineChart(Sensor sensor, LineChart lineChart) {
         this.sensor = sensor;
         this.lineChart = lineChart;
+        lastTimeStamp = 0;
     }
 
     public Sensor getSensor() {
@@ -33,5 +34,18 @@ public class SensorLineChart {
 
     public boolean isVisible() {
         return visible;
+    }
+
+    public boolean getAcceptsRequest(long timeStamp) {
+        if (lastTimeStamp +  50000000 <= timeStamp) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    public void setLastTimeStamp(long timeStamp) {
+        lastTimeStamp = timeStamp;
     }
 }

--- a/app/src/main/java/de/haw_hamburg/sensorapp/recorder/settings/RecorderSettingsFragment.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/recorder/settings/RecorderSettingsFragment.java
@@ -37,10 +37,10 @@ public class RecorderSettingsFragment extends BaseMvpFragment<RecorderSettingsPr
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         sensorsRecyclerView = (RecyclerView) view.findViewById(R.id.sensorsRecyclerView);
-        sensorsRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         sensorsRecyclerViewAdapter = new SensorsRecyclerViewAdapter();
         sensorsRecyclerViewAdapter.setListener(this::toggleSensor);
         sensorsRecyclerView.setAdapter(sensorsRecyclerViewAdapter);
+        sensorsRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         getPresenter().loadSensors();
     }
 

--- a/app/src/main/java/de/haw_hamburg/sensorapp/recorder/settings/SensorsRecyclerViewAdapter.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/recorder/settings/SensorsRecyclerViewAdapter.java
@@ -43,6 +43,7 @@ class SensorsRecyclerViewAdapter extends SectionedRecyclerViewAdapter<SensorsRec
 
     @Override
     public void onBindItemViewHolder(ItemViewHolder holder, int section, int item) {
+        holder.setOnCheckedChangeListener(null);
         Sensor sensor = sensorCategories.get(section).getSensor(item);
         holder.setText(sensor.getName());
         holder.setChecked(sensor.isEnabled());
@@ -51,6 +52,7 @@ class SensorsRecyclerViewAdapter extends SectionedRecyclerViewAdapter<SensorsRec
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (listener != null) {
                     listener.onSensorCheckedChanged(sensor, isChecked);
+                    sensorCategories.get(section).getSensor(item).setEnabled(isChecked);
                 }
             }
         });

--- a/app/src/main/java/de/haw_hamburg/sensorapp/sensor/SensorEventListenerInteractor.java
+++ b/app/src/main/java/de/haw_hamburg/sensorapp/sensor/SensorEventListenerInteractor.java
@@ -19,6 +19,6 @@ public class SensorEventListenerInteractor {
     }
 
     public Observable<SensorEvent> execute(Sensor sensor) {
-        return rxSensorManager.observeSensorEvents(sensor.getType(), SensorManager.SENSOR_DELAY_FASTEST);
+        return rxSensorManager.observeSensorEvents(sensor.getType(), 50000);
     }
 }


### PR DESCRIPTION
…ding / Fix settingslist not updating / Fix live-chart lagging issue / Screen now doesnt turn off while recording / targeted sensor-delay is now set to 50ms to enhance app performance

Habe alle mir aufgefallenen Ursachen für Abstürze der App behoben. In den meißten Fällen waren es Interaktionsmöglichkeiten beim gleichzeitigen Aufnehmen von Sensordaten. Zb nen Sensor in den Settings ausstellen oder auf nen anderes Fragment wechseln oder die App schließen wärend eine File geschrieben wird. Heap allocation errors können wohl immer noch auftreten denke ich. Je länger man mit den Live-Charts und dem Recorder rumspielt, desto größer wird der RAM-Verbrauch. Genaue Ursache konnte ich nicht feststellen. Der Emitterbuffer im rxandroidsensor package war jedenfalls nicht der Grund. Ich vermute mal, dass die ganzen csv's im Arbeitsspeicher gespeichert werden wenn man keine Speicherkarte im Gerät hat.